### PR TITLE
Add ISieveMesh for mod compatibility

### DIFF
--- a/src/main/java/exnihiloomnia/blocks/sieves/BlockSieve.java
+++ b/src/main/java/exnihiloomnia/blocks/sieves/BlockSieve.java
@@ -3,7 +3,7 @@ package exnihiloomnia.blocks.sieves;
 import exnihiloomnia.ENOConfig;
 import exnihiloomnia.blocks.sieves.tileentity.TileEntitySieve;
 import exnihiloomnia.items.ENOItems;
-import exnihiloomnia.items.meshs.ItemMesh;
+import exnihiloomnia.items.meshs.ISieveMesh;
 import exnihiloomnia.registries.sifting.SieveRegistry;
 import exnihiloomnia.util.helpers.InventoryHelper;
 import net.minecraft.block.Block;
@@ -90,7 +90,7 @@ public class BlockSieve extends Block implements ITileEntityProvider {
 				}
 				else
 				{
-					if (item != null && item.getItem() instanceof ItemMesh)
+					if (item != null && item.getItem() instanceof ISieveMesh)
 					{
 						ItemStack mesh = item.copy();
 						mesh.stackSize = 1;

--- a/src/main/java/exnihiloomnia/blocks/sieves/tileentity/TileEntitySieve.java
+++ b/src/main/java/exnihiloomnia/blocks/sieves/tileentity/TileEntitySieve.java
@@ -1,7 +1,7 @@
 package exnihiloomnia.blocks.sieves.tileentity;
 
 import exnihiloomnia.client.particles.ParticleSieve;
-import exnihiloomnia.items.meshs.ItemMesh;
+import exnihiloomnia.items.meshs.ISieveMesh;
 import exnihiloomnia.registries.sifting.SieveRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -224,7 +224,7 @@ public class TileEntitySieve extends TileEntity implements ITickable {
 	public TextureAtlasSprite getMeshTexture()
 	{
 		if (mesh != null)
-			return ((ItemMesh) mesh.getItem()).getMeshTexture();
+			return ((ISieveMesh) mesh.getItem()).getMeshTexture();
 		else
 			return null;
 	}

--- a/src/main/java/exnihiloomnia/items/meshs/ISieveMesh.java
+++ b/src/main/java/exnihiloomnia/items/meshs/ISieveMesh.java
@@ -1,0 +1,7 @@
+package exnihiloomnia.items.meshs;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+public interface ISieveMesh {
+	TextureAtlasSprite getMeshTexture();
+}

--- a/src/main/java/exnihiloomnia/items/meshs/ItemMesh.java
+++ b/src/main/java/exnihiloomnia/items/meshs/ItemMesh.java
@@ -8,7 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemMesh extends Item{
+public class ItemMesh extends Item implements ISieveMesh {
 	private String texture_location;
 	
 	public ItemMesh()
@@ -27,6 +27,7 @@ public class ItemMesh extends Item{
 	}
 	
 	@SideOnly(Side.CLIENT)
+	@Override
 	public TextureAtlasSprite getMeshTexture()
 	{
 		return Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture_location);


### PR DESCRIPTION
This extracts the getMeshTexture() method into an interface ISieveMesh, that allows other mods to define sieve mesh items without having to extend your ItemMesh class.

I'm in the process of porting my addon [Ex Compressum](https://minecraft.curseforge.com/projects/ex-compressum) and I need to support both Omnia and Insaneau's Adscensio. This change would let me make my Iron Mesh (used for sifting of compressed blocks in my Heavy Sieve, but also has more durability than the normal mesh) work in your sieves as well, without adding a hard dependency to your mod, thanks to Forge's @Optional.Interface magic.
