### PR TITLE
Fix NullPointerException when a hammer is used by a ExtraUtils2 MechanicalUser

### DIFF
--- a/src/main/java/exnihiloomnia/registries/hammering/HammerRegistryEntry.java
+++ b/src/main/java/exnihiloomnia/registries/hammering/HammerRegistryEntry.java
@@ -18,28 +18,28 @@ public class HammerRegistryEntry {
 	private IBlockState input;
 	private EnumMetadataBehavior behavior = EnumMetadataBehavior.SPECIFIC;
 	private ArrayList<HammerReward> rewards = new ArrayList<HammerReward>();
-	
+
 	public HammerRegistryEntry(IBlockState input, EnumMetadataBehavior behavior) {
 		this.input = input;
 		this.behavior = behavior;
 	}
-	
+
 	public IBlockState getInput() {
 		return input;
 	}
-	
+
 	public void addReward(ItemStack item, int base_chance, int luck_modifier) {
 		this.rewards.add(new HammerReward(item, base_chance, luck_modifier));
 	}
-	
+
 	public ArrayList<HammerReward> getRewards() {
 		return rewards;
 	}
-	
+
 	public EnumMetadataBehavior getMetadataBehavior() {
 		return this.behavior;
 	}
-	
+
 	public void dropRewards(EntityPlayer player, BlockPos pos) {
 		for (HammerReward reward : rewards) {
 			reward.dropReward(player, pos);
@@ -49,15 +49,19 @@ public class HammerRegistryEntry {
 	public List<ItemStack> rollRewards(EntityPlayer player) {
 		ArrayList<ItemStack> rewards = new ArrayList<ItemStack>();
 
-		for (HammerReward reward : this.rewards)
-			rewards.add(reward.getReward(player));
+		for (HammerReward reward : this.rewards) {
+			ItemStack itemReward = reward.getReward(player);
+			if (itemReward != null) {
+				rewards.add(itemReward);
+			}
+		}
 
 		return rewards;
 	}
-	
+
 	public String getKey() {
 		String s = Block.REGISTRY.getNameForObject(input.getBlock()).toString();
-		
+
 		if (behavior == EnumMetadataBehavior.IGNORED) {
 			return s + ":*";
 		}
@@ -65,7 +69,7 @@ public class HammerRegistryEntry {
 			return s + ":" + input.getBlock().getMetaFromState(input);
 		}
 	}
-	
+
 	public static HammerRegistryEntry fromRecipe(HammerRecipe recipe) {
 		Block block = Block.REGISTRY.getObject(new ResourceLocation(recipe.getId()));
 
@@ -77,12 +81,12 @@ public class HammerRegistryEntry {
 
 				for (HammerRecipeReward reward : recipe.getRewards()) {
 					Item item = Item.REGISTRY.getObject(new ResourceLocation(reward.getId()));
-					
+
 					if (item != null) {
 						entry.addReward(new ItemStack(item, reward.getAmount(), reward.getMeta()), reward.getBaseChance(), reward.getFortuneModifier());
 					}
 				}
-				
+
 				return entry;
 			}
 		}


### PR DESCRIPTION
Fixing a NullPointerException caused by null values in the drop list after using a hammer.

I think this should also fix #66 (similar exception)
