### PR TITLE
Fix NPE in new handling of stones->cobblestone. Array must b…

### DIFF
--- a/src/main/java/exnihiloomnia/crafting/recipes/MiscRecipes.java
+++ b/src/main/java/exnihiloomnia/crafting/recipes/MiscRecipes.java
@@ -37,14 +37,14 @@ public class MiscRecipes {
 						'y', new ItemStack(Items.SLIME_BALL, 1)));
 
 		if (ENOCrafting.stone_required > 0) {
-			Item[] stones = new Item[9];
+			Item[] stones = new Item[ENOCrafting.stone_required];
 
 			for (int i = 0; i < ENOCrafting.stone_required; i++) {
 				if (i <= stones.length)
 					stones[i] = ENOItems.STONE;
 			}
 
-			GameRegistry.addShapelessRecipe(new ItemStack(Blocks.COBBLESTONE), stones);
+			GameRegistry.addShapelessRecipe(new ItemStack(Blocks.COBBLESTONE), (Object[])stones);
 		}
 
 		//porcelain


### PR DESCRIPTION
…e the right length or the trailing nulls cause this issue if the number of stones in the recipe is less than the array size (which was 9).

Also cast it to (Object[]) so the compiler stops warning of "non-varargs call of varargs method with inexact argument type for last parameter".
Tested with 4 stones per cobble and works fine.