### PR TITLE
Added support for Draconic Evolution draconium.

### DIFF
--- a/src/main/java/exnihiloomnia/ENO.java
+++ b/src/main/java/exnihiloomnia/ENO.java
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-@Mod(name = ENO.NAME, modid = ENO.MODID, version = ENO.VERSION, dependencies = "after:tconstruct;after:mekanism;after:IC2;after:appliedenergistics2;after:FunOres")
+@Mod(name = ENO.NAME, modid = ENO.MODID, version = ENO.VERSION, dependencies = "after:tconstruct;after:mekanism;after:IC2;after:appliedenergistics2;after:FunOres;after:draconicevolution")
 public class ENO {
 
 	static {

--- a/src/main/java/exnihiloomnia/compatibility/ENOOres.java
+++ b/src/main/java/exnihiloomnia/compatibility/ENOOres.java
@@ -36,6 +36,7 @@ public class ENOOres {
     public static boolean force_ardite;
     public static boolean force_cobalt;
     public static boolean force_aluminum;
+    public static boolean force_draconium;
 
     public static boolean oredict_gravels;
     public static boolean oredict_sand;
@@ -55,6 +56,7 @@ public class ENOOres {
         force_osmium = ENO.config.get(ORE_CATAGORY, "force osmium", false).getBoolean(false);
         force_ardite = ENO.config.get(ORE_CATAGORY, "force ardite", false).getBoolean(false);
         force_cobalt = ENO.config.get(ORE_CATAGORY, "force cobalt", false).getBoolean(false);
+        force_draconium = ENO.config.get(ORE_CATAGORY, "force draconium", false).getBoolean(false);
 
         oredict_gravels = ENO.config.get(ORE_CATAGORY, "add gravel ores to the ore dictionary", false).getBoolean(false);
         oredict_sand = ENO.config.get(ORE_CATAGORY, "add sand ores to the ore dictionary", false).getBoolean(false);
@@ -102,6 +104,9 @@ public class ENOOres {
 
         if (OreDictionary.getOres("oreOsmium").size() > 0 || force_osmium)
             ores.add(EnumOre.OSMIUM);
+
+        if (OreDictionary.getOres("oreDraconium").size() > 0 || force_draconium)
+            ores.add(EnumOre.DRACONIUM);
 
         return ores;
     }

--- a/src/main/java/exnihiloomnia/compatibility/tconstruct/TinkersCompatibility.java
+++ b/src/main/java/exnihiloomnia/compatibility/tconstruct/TinkersCompatibility.java
@@ -118,6 +118,9 @@ public class TinkersCompatibility {
             case ARDITE:
                 return FluidRegistry.getFluid("ardite");
 
+            case DRACONIUM:
+                return FluidRegistry.getFluid("draconium");
+
             default:
                 return null;
         }

--- a/src/main/java/exnihiloomnia/util/enums/EnumOre.java
+++ b/src/main/java/exnihiloomnia/util/enums/EnumOre.java
@@ -15,7 +15,8 @@ public enum EnumOre implements IStringSerializable {
 	ALUMINUM(8, "aluminum", new Color("FFC7C7"), true, false, true, 20),
 	OSMIUM(9, "osmium", new Color("608FC4"), true, false, false, 20),
 	ARDITE(10, "ardite", new Color("FF4D00"), false, true, false, 2),
-	COBALT(11, "cobalt", new Color("0B91FF"), false, true, false, 2);
+	COBALT(11, "cobalt", new Color("0B91FF"), false, true, false, 2),
+	DRACONIUM(12, "draconium", new Color("733DAB"), false, false, true, 2);
 
 	private final int meta;
 	private final String name;

--- a/src/main/resources/assets/exnihiloomnia/blockstates/ore_dust.json
+++ b/src/main/resources/assets/exnihiloomnia/blockstates/ore_dust.json
@@ -21,7 +21,8 @@
             "platinum": { "textures": { "all": "exnihiloomnia:ore_dust_platinum" } },
             "cobalt": { "textures": { "all": "exnihiloomnia:ore_dust_cobalt" } },
             "ardite": { "textures": { "all": "exnihiloomnia:ore_dust_ardite" } },
-            "osmium": { "textures": { "all": "exnihiloomnia:ore_dust_osmium" } }
+            "osmium": { "textures": { "all": "exnihiloomnia:ore_dust_osmium" } },
+            "draconium": { "textures": { "all": "exnihiloomnia:ore_dust_draconium" } }
         }
     }
 }

--- a/src/main/resources/assets/exnihiloomnia/blockstates/ore_gravel_ender.json
+++ b/src/main/resources/assets/exnihiloomnia/blockstates/ore_gravel_ender.json
@@ -21,7 +21,8 @@
             "platinum": { "textures": { "all": "exnihiloomnia:ore_gravel_ender_platinum" } },
             "cobalt": { "textures": { "all": "exnihiloomnia:ore_gravel_ender_cobalt" } },
             "ardite": { "textures": { "all": "exnihiloomnia:ore_gravel_ender_ardite" } },
-            "osmium": { "textures": { "all": "exnihiloomnia:ore_gravel_ender_osmium" } }
+            "osmium": { "textures": { "all": "exnihiloomnia:ore_gravel_ender_osmium" } },
+            "draconium": { "textures": { "all": "exnihiloomnia:ore_gravel_ender_draconium" } }
         }
     }
 }

--- a/src/main/resources/assets/exnihiloomnia/blockstates/ore_sand.json
+++ b/src/main/resources/assets/exnihiloomnia/blockstates/ore_sand.json
@@ -21,7 +21,8 @@
             "platinum": { "textures": { "all": "exnihiloomnia:ore_sand_platinum" } },
             "cobalt": { "textures": { "all": "exnihiloomnia:ore_sand_cobalt" } },
             "ardite": { "textures": { "all": "exnihiloomnia:ore_sand_ardite" } },
-            "osmium": { "textures": { "all": "exnihiloomnia:ore_sand_osmium" } }
+            "osmium": { "textures": { "all": "exnihiloomnia:ore_sand_osmium" } },
+            "draconium": { "textures": { "all": "exnihiloomnia:ore_sand_draconium" } }
         }
     }
 }

--- a/src/main/resources/assets/exnihiloomnia/lang/de_DE.lang
+++ b/src/main/resources/assets/exnihiloomnia/lang/de_DE.lang
@@ -42,6 +42,7 @@ item.ore_broken_ender.aluminum.name= Zerbrochenes Aluminiumerz
 item.ore_broken_ender.ardite.name= Zerbrochenes Arditerz
 item.ore_broken_ender.cobalt.name= Zerbrochenes Cobalterz
 item.ore_broken_ender.osmium.name= Zerbrochenes Osmiumerz
+item.ore_broken_ender.draconium.name=Zerbrochenes Draconiumerz
 
 item.ore_crushed.iron.name= Zerstoßenes Eisenerz
 item.ore_crushed.gold.name= Zerstoßenes Golderz
@@ -55,6 +56,7 @@ item.ore_crushed.aluminum.name= Zerstoßenes Aluminiumerz
 item.ore_crushed.ardite.name= Zerstoßenes Arditerz
 item.ore_crushed.cobalt.name= Zerstoßenes Cobalterz
 item.ore_crushed.osmium.name= Zerstoßenes Osmiumerz
+item.ore_crushed.draconium.name=Zerstoßenes Drakoniumerz
 
 item.ore_powder.iron.name= Pulverisiertes Eisenerz
 item.ore_powder.gold.name= Pulverisiertes Golderz
@@ -68,6 +70,7 @@ item.ore_powder.aluminum.name= Pulverisiertes Aluminiumerz
 item.ore_powder.ardite.name= Pulverisiertes Arditerz
 item.ore_powder.cobalt.name= Pulverisiertes Cobalterz
 item.ore_powder.osmium.name= Pulverisiertes Osmiumerz
+item.ore_powder.draconium.name=Drakoniumerzstaub
 
 item.ore_ingot.iron.name= Eisenbarren
 item.ore_ingot.gold.name= Goldbarren
@@ -81,6 +84,7 @@ item.ore_ingot.aluminum.name= Aluminiumbarren
 item.ore_ingot.ardite.name= Arditbarren
 item.ore_ingot.cobalt.name= Cobaltbarren
 item.ore_ingot.osmium.name= Osmiumbarren
+item.ore_ingot.draconium.name=Drakoniumbarren
 
 tile.ore_gravel.iron.name= Eisenerzkies
 tile.ore_gravel.gold.name= Golderzkies
@@ -120,6 +124,7 @@ tile.ore_gravel_ender.aluminum.name= Ender-Aluminiumerzkies
 tile.ore_gravel_ender.ardite.name= Ender-Arditerzkies
 tile.ore_gravel_ender.cobalt.name= Ender-Cobalterzkies
 tile.ore_gravel_ender.osmium.name= Ender-Osmiumerzkies
+tile.ore_gravel_ender.draconium.name=Ender-Drakoniumerzkies
 
 tile.ore_sand.iron.name= Eisenerzsand
 tile.ore_sand.gold.name= Golderzsand
@@ -133,6 +138,7 @@ tile.ore_sand.aluminum.name= Aluminiumerzsand
 tile.ore_sand.ardite.name= Arditerzsand
 tile.ore_sand.cobalt.name= Cobalterzsand
 tile.ore_sand.osmium.name= Osmiumerzsand
+tile.ore_sand.draconium.name=Drakoniumerzsand
 
 tile.ore_dust.iron.name= Eisenerzstaub
 tile.ore_dust.gold.name= Golderzstaub
@@ -146,7 +152,7 @@ tile.ore_dust.aluminum.name= Aluminiumerzstaub
 tile.ore_dust.ardite.name= Arditerzstaub
 tile.ore_dust.cobalt.name= Cobalterzstaub
 tile.ore_dust.osmium.name= Osmiumerzstaub
-
+tile.ore_dust.draconium.name=Drakoniumstaub
 
 item.seed_oak.name=Eichel
 item.seed_dark_oak.name=Große Eichel

--- a/src/main/resources/assets/exnihiloomnia/lang/en_US.lang
+++ b/src/main/resources/assets/exnihiloomnia/lang/en_US.lang
@@ -42,6 +42,7 @@ item.ore_broken_ender.aluminum.name= Broken Aluminum Ore
 item.ore_broken_ender.ardite.name= Broken Ardite Ore
 item.ore_broken_ender.cobalt.name= Broken Cobalt Ore
 item.ore_broken_ender.osmium.name= Broken Osmium Ore
+item.ore_broken_ender.draconium.name= Broken Draconium Ore
 
 item.ore_crushed.iron.name= Crushed Iron Ore
 item.ore_crushed.gold.name= Crushed Gold Ore
@@ -55,6 +56,7 @@ item.ore_crushed.aluminum.name= Crushed Aluminum Ore
 item.ore_crushed.ardite.name= Crushed Ardite Ore
 item.ore_crushed.cobalt.name= Crushed Cobalt Ore
 item.ore_crushed.osmium.name= Crushed Osmium Ore
+item.ore_crushed.draconium.name= Crushed Draconium Ore
 
 item.ore_powder.iron.name= Powdered Iron Ore
 item.ore_powder.gold.name= Powdered Gold Ore
@@ -68,6 +70,7 @@ item.ore_powder.aluminum.name= Powdered Aluminum Ore
 item.ore_powder.ardite.name= Powdered Ardite Ore
 item.ore_powder.cobalt.name= Powdered Cobalt Ore
 item.ore_powder.osmium.name= Powdered Osmium Ore
+item.ore_powder.draconium.name= Powdered Draconium Ore
 
 item.ore_ingot.iron.name= Iron Ingot
 item.ore_ingot.gold.name= Gold Ingot
@@ -81,6 +84,7 @@ item.ore_ingot.aluminum.name= Aluminum Ingot
 item.ore_ingot.ardite.name= Ardite Ingot
 item.ore_ingot.cobalt.name= Cobalt Ingot
 item.ore_ingot.osmium.name= Osmium Ingot
+item.ore_ingot.draconium.name= Draconium Ingot
 
 tile.ore_gravel.iron.name= Iron Ore Gravel
 tile.ore_gravel.gold.name= Gold Ore Gravel
@@ -120,6 +124,7 @@ tile.ore_gravel_ender.aluminum.name= Ender Aluminum Ore Gravel
 tile.ore_gravel_ender.ardite.name= Ender Ardite Ore Gravel
 tile.ore_gravel_ender.cobalt.name= Ender Cobalt Ore Gravel
 tile.ore_gravel_ender.osmium.name= Ender Osmium Ore Gravel
+tile.ore_gravel_ender.draconium.name= Ender Draconium Ore Gravel
 
 tile.ore_sand.iron.name= Iron Ore Sand
 tile.ore_sand.gold.name= Gold Ore Sand
@@ -133,6 +138,7 @@ tile.ore_sand.aluminum.name= Aluminum Ore Sand
 tile.ore_sand.ardite.name= Ardite Ore Sand
 tile.ore_sand.cobalt.name= Cobalt Ore Sand
 tile.ore_sand.osmium.name= Osmium Ore Sand
+tile.ore_sand.draconium.name= Draconium Ore Sand
 
 tile.ore_dust.iron.name= Iron Ore Dust
 tile.ore_dust.gold.name= Gold Ore Dust
@@ -146,6 +152,7 @@ tile.ore_dust.aluminum.name= Aluminum Ore Dust
 tile.ore_dust.ardite.name= Ardite Ore Dust
 tile.ore_dust.cobalt.name= Cobalt Ore Dust
 tile.ore_dust.osmium.name= Osmium Ore Dust
+tile.ore_dust.draconium.name= Draconium Ore Dust
 
 
 item.seed_oak.name=Acorn

--- a/src/main/resources/assets/exnihiloomnia/models/item/ore_dust.draconium.json
+++ b/src/main/resources/assets/exnihiloomnia/models/item/ore_dust.draconium.json
@@ -1,0 +1,1 @@
+{"parent": "block/cube_all","textures": {"all": "exnihiloomnia:ore_dust_draconium"}}

--- a/src/main/resources/assets/exnihiloomnia/models/item/ore_gravel_ender.draconium.json
+++ b/src/main/resources/assets/exnihiloomnia/models/item/ore_gravel_ender.draconium.json
@@ -1,0 +1,1 @@
+{"parent": "block/cube_all","textures": {"all": "exnihiloomnia:ore_gravel_ender_draconium"}}

--- a/src/main/resources/assets/exnihiloomnia/models/item/ore_sand.draconium.json
+++ b/src/main/resources/assets/exnihiloomnia/models/item/ore_sand.draconium.json
@@ -1,0 +1,1 @@
+{"parent": "block/cube_all","textures": {"all": "exnihiloomnia:ore_sand_draconium"}}


### PR DESCRIPTION
Special thanks to UpcraftLP for the DE translation. Chinese translation, well... you're on your own. ;)

Added a fluid for it to the TCon integration, but it doesn't exist. Nor does it for Osmium from Mekanism, but you had that in there anyway, so I figured I would add draconium as well. You may or may not want it in there. Certainly doesn't break anything, anyway.

Everything seems to work well. You might want to tweak the probability/weight, which I set to 2, however.

EDIT: Yeah, got it to unify properly with UniDict, so you can ignore the following paragraph.
Only issue I'm having is smelting them gives an ingot from Ex Nihilo Omnia instead of Draconic Evolution (which also happens with TCon cobalt and ardite). Probably more of an issue with UniDict not unifying them with my configs. It would be far preferable if they smelted to DE and TCon ingots, and I just mention that in case it has anything to do with this software, or there's something you can do on that front. But probably a job for UniDict, anyway.

Thanks!