### PR TITLE
Added support for MoreBees.

### DIFF
--- a/src/main/java/exnihiloomnia/ENO.java
+++ b/src/main/java/exnihiloomnia/ENO.java
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-@Mod(name = ENO.NAME, modid = ENO.MODID, version = ENO.VERSION, dependencies = "after:tconstruct;after:mekanism;after:IC2;after:appliedenergistics2;after:FunOres;after:draconicevolution;after:forestry;after:immersiveengineering;after:bigreactors")
+@Mod(name = ENO.NAME, modid = ENO.MODID, version = ENO.VERSION, dependencies = "after:tconstruct;after:mekanism;after:IC2;after:appliedenergistics2;after:FunOres;after:draconicevolution;after:forestry;after:morebees;after:immersiveengineering;after:bigreactors")
 public class ENO {
 
 	static {

--- a/src/main/java/exnihiloomnia/compatibility/forestry/HiveList.java
+++ b/src/main/java/exnihiloomnia/compatibility/forestry/HiveList.java
@@ -5,6 +5,7 @@ import forestry.core.genetics.alleles.EnumAllele;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraftforge.common.BiomeDictionary;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public class HiveList {
 
@@ -17,6 +18,9 @@ public class HiveList {
     public static Hive END;
     public static Hive SNOW;
     public static Hive MARSH;
+
+    // MoreBees
+    public static Hive ROCK;
 
     public static void generateForestHive() {
         FOREST = new Hive(beehives, 0);
@@ -82,5 +86,18 @@ public class HiveList {
         MARSH.flowers = EnumAllele.Flowers.MUSHROOMS;
 
         MARSH.biomeTypes.add(BiomeDictionary.Type.SWAMP);
+    }
+
+    public static void generateRockHive() {
+        Block moreBeesHives = GameRegistry.findBlock("morebees", "hive");
+
+        if (moreBeesHives != null) {
+            ROCK = new Hive(moreBeesHives, 0);
+
+            ROCK.requiredCanSeeSky = false;
+            ROCK.requiredSubstrate = Blocks.STONE.getDefaultState();
+
+            ROCK.biomeTypes.add(BiomeDictionary.Type.HILLS);
+        }
     }
 }

--- a/src/main/java/exnihiloomnia/compatibility/forestry/HiveRegistry.java
+++ b/src/main/java/exnihiloomnia/compatibility/forestry/HiveRegistry.java
@@ -2,6 +2,7 @@ package exnihiloomnia.compatibility.forestry;
 
 import exnihiloomnia.ENO;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.common.Loader;
 
 import java.util.*;
 
@@ -50,6 +51,11 @@ public class HiveRegistry {
         registerHive(HiveList.END);
         registerHive(HiveList.SNOW);
         registerHive(HiveList.MARSH);
+
+        if (Loader.isModLoaded("morebees")) {
+            HiveList.generateRockHive();
+            registerHive(HiveList.ROCK);
+        }
 
         ENO.log.info("Hive Registry Completed!");
     }


### PR DESCRIPTION
Make sure this is done in a way you like, particularly the check to see if MoreBees is loaded. This way was expedient, but you may want to organise it differently. If it had more than one hive type, I would have made a seperate method to load all the MoreBees hives with the loaded check, and to set the hive Block object for it. But there is only one at the moment.

I tested it, and it works, though I have them able to work in any biome on my test server. They require stone substrate, don't need to see the sky, and Hills biome types. Not entirely sure about the biome type, but it seemed appropriate. So make sure you don't want to also tweak those values.

Thanks :)