### PR TITLE
Configurable NBT tags in recipe rewards

### DIFF
--- a/src/main/java/exnihiloomnia/registries/sifting/SieveRegistryEntry.java
+++ b/src/main/java/exnihiloomnia/registries/sifting/SieveRegistryEntry.java
@@ -1,5 +1,6 @@
 package exnihiloomnia.registries.sifting;
 
+import exnihiloomnia.ENO;
 import exnihiloomnia.registries.sifting.pojos.SieveRecipe;
 import exnihiloomnia.registries.sifting.pojos.SieveRecipeReward;
 import exnihiloomnia.util.enums.EnumMetadataBehavior;
@@ -8,6 +9,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTException;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.util.ResourceLocation;
 
@@ -64,23 +66,20 @@ public class SieveRegistryEntry {
 					Item item = Item.REGISTRY.getObject(new ResourceLocation(reward.getId()));
 
 					if (item != null) {
-						ItemStack rewardStack = new ItemStack(item, reward.getAmount(), reward.getMeta()), reward.getBaseChance();
-						
-						if (reward.getNBT() != '') {
-							NBTTagCompound rewardNBT;
+						ItemStack rewardStack = new ItemStack(item, reward.getAmount(), reward.getMeta());
+
+						if (reward.getNBT() != "") {
 
 							try {
-									rewardNBT = JsonToNBT.getTagFromJson(reward.getNBT());
+									NBTTagCompound rewardNBT = JsonToNBT.getTagFromJson(reward.getNBT());
+									rewardStack.setTagCompound(rewardNBT);
 							} catch (NBTException e) {
 									ENO.log.error("Error parsing NBT when loading sieve recipe for: " + recipe.getId());
 							}
 
-							if (rewardNBT != null) {
-									rewardStack.setTagCompound(rewardNBT);
-							}
 						}
 
-						entry.addReward(rewardStack);
+						entry.addReward(rewardStack, reward.getBaseChance());
 					}
 				}
 

--- a/src/main/java/exnihiloomnia/registries/sifting/SieveRegistryEntry.java
+++ b/src/main/java/exnihiloomnia/registries/sifting/SieveRegistryEntry.java
@@ -7,6 +7,8 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.ArrayList;
@@ -16,31 +18,31 @@ public class SieveRegistryEntry {
 	private final IBlockState input;
 	private EnumMetadataBehavior behavior = EnumMetadataBehavior.SPECIFIC;
 	private final ArrayList<SieveReward> rewards = new ArrayList<>();
-	
+
 	public SieveRegistryEntry(IBlockState input, EnumMetadataBehavior behavior) {
 		this.input = input;
 		this.behavior = behavior;
 	}
-	
+
 	public IBlockState getInput() {
 		return input;
 	}
-	
+
 	public void addReward(ItemStack item, int base_chance) {
 		this.rewards.add(new SieveReward(item, base_chance));
 	}
-	
+
 	public ArrayList<SieveReward> getRewards() {
 		return rewards;
 	}
-	
+
 	public EnumMetadataBehavior getMetadataBehavior() {
 		return this.behavior;
 	}
-	
+
 	public String getKey() {
 		String s = Block.REGISTRY.getNameForObject(input.getBlock()).toString();
-		
+
 		if (behavior == EnumMetadataBehavior.IGNORED) {
 			return s + ":*";
 		}
@@ -48,7 +50,7 @@ public class SieveRegistryEntry {
 			return s + ":" + input.getBlock().getMetaFromState(input);
 		}
 	}
-	
+
 	public static SieveRegistryEntry fromRecipe(SieveRecipe recipe) {
 		Block block = Block.REGISTRY.getObject(new ResourceLocation(recipe.getId()));
 
@@ -62,10 +64,26 @@ public class SieveRegistryEntry {
 					Item item = Item.REGISTRY.getObject(new ResourceLocation(reward.getId()));
 
 					if (item != null) {
-						entry.addReward(new ItemStack(item, reward.getAmount(), reward.getMeta()), reward.getBaseChance());
+						ItemStack rewardStack = new ItemStack(item, reward.getAmount(), reward.getMeta()), reward.getBaseChance();
+						
+						if (reward.getNBT() != '') {
+							NBTTagCompound rewardNBT;
+
+							try {
+									rewardNBT = JsonToNBT.getTagFromJson(reward.getNBT());
+							} catch (NBTException e) {
+									ENO.log.error("Error parsing NBT when loading sieve recipe for: " + recipe.getId());
+							}
+
+							if (rewardNBT != null) {
+									rewardStack.setTagCompound(rewardNBT);
+							}
+						}
+
+						entry.addReward(rewardStack);
 					}
 				}
-				
+
 				return entry;
 			}
 		}

--- a/src/main/java/exnihiloomnia/registries/sifting/pojos/SieveRecipeReward.java
+++ b/src/main/java/exnihiloomnia/registries/sifting/pojos/SieveRecipeReward.java
@@ -5,45 +5,55 @@ public class SieveRecipeReward {
 	private int meta;
 	private int amount;
 	private int baseChance = 0;
-	
+	private String nbt = '';
+
 	public SieveRecipeReward(){}
-	
-	public SieveRecipeReward(String id, int meta, int amount, int baseChance) {
+
+	public SieveRecipeReward(String id, int meta, int amount, int baseChance, String nbt) {
 		this.id = id;
 		this.meta = meta;
 		this.amount = amount;
 		this.baseChance = baseChance;
+		this.nbt = nbt;
 	}
-	
+
 	public String getId() {
 		return id;
 	}
-	
+
 	public void setId(String id) {
 		this.id = id;
 	}
-	
+
 	public int getMeta() {
 		return meta;
 	}
-	
+
 	public void setMeta(int meta) {
 		this.meta = meta;
 	}
-	
+
 	public int getBaseChance() {
 		return baseChance;
 	}
-	
+
 	public void setBaseChance(int baseChance) {
 		this.baseChance = baseChance;
 	}
-	
+
 	public int getAmount() {
 		return amount;
 	}
-	
+
 	public void setAmount(int amount) {
 		this.amount = amount;
+	}
+
+	public String getNBT() {
+		return nbt;
+	}
+
+	public void getNBT(String nbt) {
+		this.nbt = nbt;
 	}
 }

--- a/src/main/java/exnihiloomnia/registries/sifting/pojos/SieveRecipeReward.java
+++ b/src/main/java/exnihiloomnia/registries/sifting/pojos/SieveRecipeReward.java
@@ -5,7 +5,7 @@ public class SieveRecipeReward {
 	private int meta;
 	private int amount;
 	private int baseChance = 0;
-	private String nbt = '';
+	private String nbt = "";
 
 	public SieveRecipeReward(){}
 
@@ -15,6 +15,14 @@ public class SieveRecipeReward {
 		this.amount = amount;
 		this.baseChance = baseChance;
 		this.nbt = nbt;
+	}
+
+	public SieveRecipeReward(String id, int meta, int amount, int baseChance) {
+		this.id = id;
+		this.meta = meta;
+		this.amount = amount;
+		this.baseChance = baseChance;
+		this.nbt = "";
 	}
 
 	public String getId() {


### PR DESCRIPTION
Hi there!

I've coded up an addition to recipe configurations (for sieves only, to start with) that allows you to set NBT tags on the reward item. Here's an example recipe for Spawnercraft:

```
    {
      "id": "minecraft:magma",
      "meta": 0,
      "behavior": "meta_ignored",
      "rewards": [
        {
          "id": "spawnercraft:mobEssence",
          "meta": 0,
          "amount": 1,
          "baseChance": 5,
          "nbt": "{EntityTag: {id: \"Blaze\"}}"
        }
      ]
    }
```

The JSON in the NBT tag sadly has to be quoted and escaped, as I don't know an easy way of getting a property in a POJO to accept generic JSON - but improvements are of course welcomed!

Let me know what you think.